### PR TITLE
feat(tags): Set default tags & add opts: tags, and other resource tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## Unreleased
-- feat(control plane logging): Enable control plane logging to cloudwatch.
-  [#100](https://github.com/pulumi/pulumi-eks/pull/117).
 
 ### Improvements
 
+- chore(cluster): de-dupe creation of nodeSecurityGroup & ingress rule
+  [#121](https://github.com/pulumi/pulumi-eks/pull/121)
+- feat(control plane logging): Enable control plane logging to cloudwatch.
+  [#100](https://github.com/pulumi/pulumi-eks/pull/117).
 - fix(ami): only apply AMI smart-default selection on creation
   [#114](https://github.com/pulumi/pulumi-eks/pull/114)
 

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -120,6 +120,11 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         revokeRulesOnDelete: true,
         ingress: [],
         egress: [],
+        tags: <aws.Tags>{
+            "Name": `${name}-eksClusterSecurityGroup`,
+            ...args.tags,
+            ...args.clusterSecurityGroupTags,
+        },
     }, { parent: parent });
 
     const eksClusterInternetEgressRule = new aws.ec2.SecurityGroupRule(`${name}-eksClusterInternetEgressRule`, {
@@ -390,6 +395,11 @@ export interface ClusterOptions {
      * The subnets to use for worker nodes. Defaults to the value of subnetIds.
      */
     nodeSubnetIds?: pulumi.Input<pulumi.Input<string>[]>;
+
+    /**
+     * The tags to apply to the cluster security group.
+     */
+    clusterSecurityGroupTags?: { [key: string]: string };
 
     /**
      * The size in GiB of a cluster node's root volume. Defaults to 20.

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -78,6 +78,7 @@ export interface CoreData {
     eksNodeAccess?: k8s.core.v1.ConfigMap;
     kubeconfig?: pulumi.Output<any>;
     vpcCni?: VpcCni;
+    tags?: { [key: string]: string };
 }
 
 export function createCore(name: string, args: ClusterOptions, parent: pulumi.ComponentResource): CoreData {
@@ -280,6 +281,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         vpcCni: vpcCni,
         instanceProfile: instanceProfile,
         eksNodeAccess: eksNodeAccess,
+        tags: args.tags,
     };
 }
 
@@ -449,6 +451,12 @@ export interface ClusterOptions {
      * Defaults to `true`.
      */
     deployDashboard?: boolean;
+
+    /**
+     * Key-value mapping of tags that are automatically applied to all AWS
+     * resources directly under management with this cluster, which support tagging.
+    */
+    tags?: { [key: string]: string };
 
     /**
      * Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -68,6 +68,16 @@ func Test_Examples(t *testing.T) {
 			},
 			ExpectRefreshChanges: true,
 		},
+		{
+			Dir: path.Join(cwd, "./tags"),
+			Config: map[string]string{
+				"aws:region": region,
+			},
+			Dependencies: []string{
+				"@pulumi/eks",
+			},
+			ExpectRefreshChanges: true,
+		},
 	}
 
 	longTests := []integration.ProgramTestOptions{}

--- a/nodejs/eks/examples/tags/Pulumi.yaml
+++ b/nodejs/eks/examples/tags/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: tags
+description: EKS cluster and nodegroups with various types of AWS resource tagging
+runtime: nodejs

--- a/nodejs/eks/examples/tags/README.md
+++ b/nodejs/eks/examples/tags/README.md
@@ -1,0 +1,11 @@
+# examples/tags
+
+Demonstrates how to use cluster and resource tags in differnt ways with Node Groups.
+
+For each case, it will create an EKS cluster in the default VPC without worker nodes.
+
+Then, create the following clusters:
+* Simple case - apply tags to all cluster managed resources, as well as apply specific resource tags.
+* Advanced case:
+  * ondemand node group on the Cluster, using node group specific resource tags.
+  * spot price node group, using the Cluster, and node group specific resource tags.

--- a/nodejs/eks/examples/tags/iam.ts
+++ b/nodejs/eks/examples/tags/iam.ts
@@ -1,0 +1,27 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+];
+
+// Creates a role and attches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}

--- a/nodejs/eks/examples/tags/index.ts
+++ b/nodejs/eks/examples/tags/index.ts
@@ -1,0 +1,77 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as iam from "./iam";
+
+// Create an EKS cluster with cluster and resource tags.
+const cluster1 = new eks.Cluster("tags-cluster1", {
+    instanceType: "t2.medium",
+    desiredCapacity: 1,
+    minSize: 1,
+    maxSize: 2,
+    tags: {
+        "project": "foobar",
+        "org": "barfoo",
+    },
+    clusterSecurityGroupTags: { "myClusterSecurityGroupTag1": "true" },
+    deployDashboard: false,
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig1 = cluster1.kubeconfig;
+
+// Create an EKS cluster with no default node group.
+const role0 = iam.createRole("tags-myrole0");
+const instanceProfile0 = new aws.iam.InstanceProfile("tags-myInstanceProfile0", {role: role0});
+const cluster2 = new eks.Cluster("tags-cluster2", {
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+    instanceRole: role0,
+    tags: {
+        "project": "foo",
+        "org": "bar",
+    },
+    clusterSecurityGroupTags: { "myClusterSecurityGroupTag2": "true" },
+});
+
+// There are two approaches that can be used to add additional NodeGroups.
+// 1. A `createNodeGroup` API on `eks.Cluster`
+// 2. A `NodeGroup` resource which accepts an `eks.Cluster` as input
+
+// Create the node group using an on-demand instance and resource tags.
+cluster2.createNodeGroup("ng-tags-ondemand", {
+    instanceType: "t2.medium",
+    desiredCapacity: 1,
+    minSize: 1,
+    maxSize: 2,
+    labels: {"ondemand": "true"},
+    instanceProfile: instanceProfile0,
+    nodeSecurityGroupTags: { "myNodeSecurityGroupTag2": "true" },
+    autoScalingGroupTags: { "myAutoScalingGroupTag2": "true" },
+    cloudFormationTags: { "myCloudFormationTag2": "true" },
+});
+
+// Create the second node group using a spot price instance and resource tags.
+const spot = new eks.NodeGroup("ng-tags-spot", {
+    cluster: cluster2,
+    instanceType: "t2.medium",
+    desiredCapacity: 1,
+    minSize: 1,
+    maxSize: 2,
+    spotPrice: "1",
+    instanceProfile: instanceProfile0,
+    labels: {"preemptible": "true"},
+    taints: {
+        "special": {
+            value: "true",
+            effect: "NoSchedule",
+        },
+    },
+    nodeSecurityGroupTags: { "myNodeSecurityGroupTag3": "true" },
+    autoScalingGroupTags: { "myAutoScalingGroupTag3": "true" },
+    cloudFormationTags: { "myCloudFormationTag3": "true" },
+}, {
+    providers: { kubernetes: cluster2.provider},
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig2 = cluster2.kubeconfig;

--- a/nodejs/eks/examples/tags/package.json
+++ b/nodejs/eks/examples/tags/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "nodegroup",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest",
+        "sync-request": "^6.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/tags/tsconfig.json
+++ b/nodejs/eks/examples/tags/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -143,6 +143,11 @@ export interface NodeGroupBaseOptions {
      * must be supplied in the ClusterOptions as either: 'instanceRole', or as a role of 'instanceRoles'.
      */
     instanceProfile?: aws.iam.InstanceProfile;
+
+    /**
+     * The tags to apply to the Worker Nodes security group.
+     */
+    nodeSecurityGroupTags?: { [key: string]: string };
 }
 
 /**
@@ -247,6 +252,7 @@ export function createNodeGroup(name: string, args: NodeGroupOptions, parent: pu
             vpcId: core.vpcId,
             clusterSecurityGroup: core.clusterSecurityGroup,
             eksCluster: eksCluster,
+            tags: <aws.Tags>{...core.tags, ...args.nodeSecurityGroupTags},
         }, parent);
         eksClusterIngressRule = new aws.ec2.SecurityGroupRule(`${name}-eksClusterIngressRule`, {
             description: "Allow pods to communicate with the cluster API Server",

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -153,6 +153,11 @@ export interface NodeGroupBaseOptions {
      * The tags to apply to the NodeGroup's AutoScalingGroup.
      */
     autoScalingGroupTags?: { [key: string]: string };
+
+    /**
+     * The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
+     */
+    cloudFormationTags?: { [key: string]: string };
 }
 
 /**
@@ -488,6 +493,11 @@ ${customUserData}
     const cfnStack = new aws.cloudformation.Stack(`${name}-nodes`, {
         name: cfnStackName,
         templateBody: cfnTemplateBody,
+        tags: <aws.Tags>{
+            "Name": `${name}-nodes`,
+            ...core.tags,
+            ...args.cloudFormationTags,
+        },
     }, { parent: parent, dependsOn: cfnStackDeps });
 
     const autoScalingGroupName = cfnStack.outputs.apply(outputs => <string>outputs["NodeGroup"]);

--- a/nodejs/eks/securitygroup.ts
+++ b/nodejs/eks/securitygroup.ts
@@ -26,6 +26,11 @@ export interface NodeGroupSecurityGroupOptions {
      */
     clusterSecurityGroup: aws.ec2.SecurityGroup;
 
+    /*
+     * Key-value mapping of tags to apply to this security group.
+     */
+    tags?: { [key: string]: string };
+
     /**
      * The security group associated with the EKS cluster.
      */
@@ -39,7 +44,9 @@ export function createNodeGroupSecurityGroup(name: string, args: NodeGroupSecuri
         ingress: [],
         egress: [],
         tags: args.eksCluster.name.apply(n => <aws.Tags>{
+            "Name": `${name}-nodeSecurityGroup`,
             [`kubernetes.io/cluster/${n}`]: "owned",
+            ...args.tags,
         }),
     }, { parent: parent });
 


### PR DESCRIPTION
Fixes https://github.co/pulumi/pulumi-eks/issues/74.

This PR does the following:

- Adds a couple of new options:
  - `Cluster` class:
    - `.tags` - A map of tags that is applied to all AWS resources under management by a `pulumi/eks` cluster. Currently applied to: `eksClusterSecurityGroup`, `nodeSecurityGroup`, the Worker AutoScalingGroup (ASG) and cloudFormation stack.
    - `.clusterSecurityGroupTags` - A map of tags applied to the EKS Cluster security group
  - `NodeGroup` class:
    - `.nodeSecurityGroupTags` - A map of tags applied to the Worker Nodes security group
    - `.cloudFormationTags` - A map of tags applied to the CloudFormation Stack of Worker Nodes
    - `.autoScalingGroupTags` - A map of tags applied to the Worker NodeGroup ASG & Instances
- Also, set the default `"Name"` tag for each: `eksClusterSecurityGroup`, `nodeSecurityGroup`, and the Worker CloudFormation stack. The Worker ASG already had one set.

See the table for the:
- AWS resources under management by the cluster
- their new resource tag `xTags` name (if applicable)
- whether it has the default `"Name"` tag, and
- if it includes the `.tags` set for all resources under management by the cluster.

| AWS Resource  | Can be tagged? | Resource Tag Name | Has default 'Name' Tag? |  Includes `.tags`
| ------------- | ------------- | ------------- | ------------- | ------------- |
| eksCluster  | No  | | | |
| eksClusterIngressRule  | No  | | | |
| eksClusterInternetEgressRule   | No  | | | |
| eksClusterSecurityGroup  | Yes  | `clusterSecurityGroupTags` | Yes | Yes |
| eksExtApiServerClusterIngressRule    | No  | | | |
| eksNodeClusterIngressRule     | No  | | | |
| eksNodeIngressRule      | No  | | | |
| eksNodeInternetEgressRule      | No  | | | |
| eksRole  | Yes | see ([#119](https://github.co/pulumi/pulumi-eks/issues/119)) | Not yet | Not yet | *
| 2x eksRolePolicyAttachment      | No  | | | |
| instanceProfile  | No  | | | |
| instanceRole  | Yes | see ([#119](https://github.co/pulumi/pulumi-eks/issues/119)) | Not yet | Not yet | *
| 3x instanceRolePolicyAttachment      | No  | | | |
| nodeLaunchConfiguration  | No | | | |
| nodeSecurityGroup  | Yes | `nodeSecurityGroupTags` | Yes | Yes |
| autoScalingGroup & Instances | Yes | `autoScalingGroupTags` | Yes | Yes |
| cloudFormation Stack  | Yes | `cloudFormationTags` | Yes | Yes |